### PR TITLE
Removing links to old builds

### DIFF
--- a/src/views/Download.tsx
+++ b/src/views/Download.tsx
@@ -32,7 +32,7 @@ class Download extends React.Component {
             return (
               <tr key={i}>
                 <td>{info.date.format("MMMM Do YYYY")}</td>
-                <td><a target="_blank noopener noreferrer" href={info.link} style={{textDecoration: "underline"}}>{info.version}</a></td>
+                <td>{info.version}</td>
                 <td>{info.changelog ? this.renderChangelogList(info.changelog) : undefined}</td>
               </tr>
             )


### PR DESCRIPTION
- [x] Download links are no longer included in historical changelog lists
    - Note: There's no need to remove all the old download links from the changelog file... They don't do anything anymore and it's less work to just leave them